### PR TITLE
Fixes nightly compilation problems

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -384,7 +384,7 @@ impl<
             }
             // Iterates over thread handles to see if they timed out or if we need to join
             // terminated threads.
-            worker_handles.drain_filter(|instance, handle| {
+            let _ = worker_handles.extract_if(|instance, handle| {
                 // If there is still an handle associated to this thread...
                 if let Some(join_handle) = handle.join_handle.as_mut() {
                     // ... and the thread has finished running...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 
 
 #![feature(exclusive_range_pattern)]
-#![feature(hash_drain_filter)]
+#![feature(hash_extract_if)]
 #![feature(iterator_try_collect)]
 #![feature(map_try_insert)]
 #![feature(portable_simd)]


### PR DESCRIPTION
`hash_drain_filter` got renamed to `hash_extract_if` in https://github.com/rust-lang/rust/pull/104455. This PR applies the appropriate fix.