### PR TITLE
fix: correct occured to occurred typo in source comments and error messages

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -353,7 +353,7 @@ impl<
                         worker.run(i == 0, iterations)?;
                         Ok(())
                     })
-                    .expect("An error occured while spawning a worker thread");
+                    .expect("An error occurred while spawning a worker thread");
                 // Receives the VcpuInstance of the thread we've just created.
                 let instance = instance_rx.recv().unwrap();
                 let handle = WorkerHandle::new(handle);
@@ -392,7 +392,7 @@ impl<
                         // ... then join the thread.
                         if let Some(h) = handle.join_handle.take() {
                             h.join()
-                                .expect("An error occured while joining threads")
+                                .expect("An error occurred while joining threads")
                                 .expect("thread panicked");
                         }
                         false
@@ -444,7 +444,7 @@ impl WorkerHandle {
     }
 }
 
-/// Stores information about the number of testcases, crashes and timeouts that occured during a
+/// Stores information about the number of testcases, crashes and timeouts that occurred during a
 /// given time interval.
 ///
 /// This object is sent from worker threads back to the main one through an [`std::sync::mpsc`]
@@ -526,8 +526,8 @@ impl WorkerInfo {
 ///  * running the [`Loader::pre_exec`](crate::loader::Loader::pre_exec) hook;
 ///  * running the testcase using [`Executor::vcpu_run`];
 ///  * running the [`Loader::post_exec`](crate::loader::Loader::post_exec) hook;
-///  * checking if a crash or a timeout occured;
-///     * if a crash occured, rerun the testcase with the backtrace hooks enabled and check if the
+///  * checking if a crash or a timeout occurred;
+///     * if a crash occurred, rerun the testcase with the backtrace hooks enabled and check if the
 ///       crash is already known;
 ///     * if it's a new crash, store it;
 ///  * checking if new paths have been covered by the current testcase;
@@ -1577,7 +1577,7 @@ impl<L: Loader + Loader<LD = LD> + Loader<GD = GD>, LD: Clone, GD: Clone> Execut
             }
             let ek = self.run_inner(&mut loader)?;
             match ek {
-                // If a crash or a timeout occured, we propagate the info.
+                // If a crash or a timeout occurred, we propagate the info.
                 ExitKind::Crash(_) | ExitKind::Timeout => {
                     self.loader_copy = Some(loader);
                     return Ok(ek);

--- a/src/crash.rs
+++ b/src/crash.rs
@@ -1,4 +1,4 @@
-//! Methods to create crash files after a crash or a timeout occured.
+//! Methods to create crash files after a crash or a timeout occurred.
 
 use std::fs;
 use std::io::Write as IoWrite;
@@ -15,12 +15,12 @@ use crate::utils::*;
 /// Represents the type of exit can be returned after the execution of a testcase.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ExitKind {
-    /// Resumes the execution after an exception occured and was handled.
+    /// Resumes the execution after an exception occurred and was handled.
     Continue,
     /// The execution continues, but we signaled that we returned early from the function
     /// (kind of a hack to update the backtrace even if we didn't execute the return instruction).
     EarlyFunctionReturn,
-    /// An exception occured and resulted in a crash. Stores the title of the crash report.
+    /// An exception occurred and resulted in a crash. Stores the title of the crash report.
     Crash(String),
     /// The execution timed out.
     Timeout,

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,7 +125,7 @@ pub enum CoreError {
     CorpusCrash(std::path::PathBuf),
     /// The testcase provided is invalid.
     InvalidTestcase,
-    /// An I/O error occured while processing the corpus.
+    /// An I/O error occurred while processing the corpus.
     IoError(String),
     /// Too many workers are trying to be spawned.
     TooManyWorkers(u32),
@@ -158,7 +158,7 @@ impl fmt::Display for CoreError {
 /// Crash-related errors.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CrashError {
-    /// A format error occured.
+    /// A format error occurred.
     FmtError(std::fmt::Error),
     /// User-defined core error.
     Generic(String),
@@ -300,7 +300,7 @@ impl fmt::Display for MemoryError {
             MemoryError::InvalidSize(s) => write!(f, "invalid size: {:#x}", s),
             MemoryError::LayoutError(e) => write!(f, "layout error: {}", e),
             MemoryError::OutOfMemory => write!(f, "the allocator ran out of memory"),
-            MemoryError::Overflow(a, s) => write!(f, "an overflow occured: {:#x}, {:#x}", a, s),
+            MemoryError::Overflow(a, s) => write!(f, "an overflow occurred: {:#x}, {:#x}", a, s),
             MemoryError::UnalignedAddress(a) => write!(f, "unaligned address: ({:#x})", a),
             MemoryError::UnalignedSize(s) => write!(f, "unaligned size: ({:#x})", s),
             MemoryError::UnallocatedMemoryAccess(x) => {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -213,7 +213,7 @@ pub const END_ADDR: u64 = 0xdead_beef_0bad_0d0e;
 ///
 /// # Role of Exceptions in the Fuzzer
 ///
-/// Exceptions are an integral part of the fuzzer: whether it's to detect that a crash occured or
+/// Exceptions are an integral part of the fuzzer: whether it's to detect that a crash occurred or
 /// to track dirty states for virtual memory pages, we have to handle them appropriately to
 /// resume the execution or exit gracefully.
 ///
@@ -263,7 +263,7 @@ pub const END_ADDR: u64 = 0xdead_beef_0bad_0d0e;
 /// there to handle the exception, but we're actually going to propagate the exception to the
 /// hypervisor using HVC (hypervisor calls) instructions. Each entry will have an ID, from 0 to 15,
 /// that we can encode into the HVC instruction and that we can retrieve when the exception is
-/// raised to the hypervisor. This way, we'll be able to identify which exception occured at EL0 or
+/// raised to the hypervisor. This way, we'll be able to identify which exception occurred at EL0 or
 /// EL1 and handle it appropriately.
 ///
 /// ```text
@@ -333,7 +333,7 @@ impl Exceptions {
     }
 
     /// Handles exceptions raised to the hypervisor. The least significant bits of the exception
-    /// syndrome contains the ID of the original exception that occured in the guest VM.
+    /// syndrome contains the ID of the original exception that occurred in the guest VM.
     /// The corresponding handlers for each exception come from the user-defined loader.
     #[allow(clippy::single_match)]
     pub fn handle_hvc<L: Loader + Loader<LD = LD> + Loader<GD = GD>, LD: Clone, GD: Clone>(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -803,7 +803,7 @@ impl Default for Symbols {
 ///     let mut hp = HyperPom::<_, _, _>::new(config, loader, ldata, gdata)
 ///         .expect("could not create fuzzer");
 ///     // Start fuzzing!
-///     hp.fuzz().expect("an error occured while fuzzing");
+///     hp.fuzz().expect("an error occurred while fuzzing");
 /// }
 /// ```
 ///

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1532,8 +1532,8 @@ impl PageTableManager {
     ///
     /// This functions returns:
     ///
-    ///  * `Ok(true)` if a remapping occured because `descriptor_in_use` and `descriptor` differ.
-    ///  * `Ok(false)` if no remapping occured since the descriptors were the same.
+    ///  * `Ok(true)` if a remapping occurred because `descriptor_in_use` and `descriptor` differ.
+    ///  * `Ok(false)` if no remapping occurred since the descriptors were the same.
     ///
     /// This value is used by the data abort exception handler to decide whether it needs to retry
     /// the faulting exception after a remapping or if it should propagate the exception to the
@@ -1767,7 +1767,7 @@ impl Clone for VirtMemAllocator {
         // Retrieves the physical memory allocator from the SlabAllocator in PageTableManager.
         let pma = self.upper_table.slab.pma.clone();
         let mut vma =
-            VirtMemAllocator::new(pma).expect("error occured while cloning VirtMemAllocator");
+            VirtMemAllocator::new(pma).expect("error occurred while cloning VirtMemAllocator");
         // Iterates over each allocated page in the page table for the lower virtual address range.
         for (&addr, page) in self.lower_table.allocs.iter() {
             let page = page.borrow();


### PR DESCRIPTION
## Summary
Corrects the spelling of `occurred` (replaces `occured`) across 6 source files in the AArch64 hypervisor fuzzer codebase.

## Changes
| File | Changes |
|------|---------|
| src/core.rs | 4 occurrences: expect() error messages + doc comments |
| src/crash.rs | 3 occurrences: doc comments + ExitKind variant docs |
| src/error.rs | 3 occurrences: doc comments + format string |
| src/exceptions.rs | 3 occurrences: doc comments |
| src/loader.rs | 1 occurrence: example code |
| src/memory.rs | 3 occurrences: doc comments + expect() string |

**Total: 6 files, 17 typo fixes**

## Type
- 5 fixes in user-facing error messages (runtime panic messages)
- 12 fixes in doc comments

## Verification
- `cargo check` passes ✅
- Single commit, GH007 compliant (commit email: 166608075+Jah-yee@users.noreply.github.com)
